### PR TITLE
Add season views

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -189,6 +189,22 @@ class Season(BaseModel):
     def duration(self):
         return self.end_date - self.start_date
 
+    @cached_property
+    def matches_count(self):
+        return self.matches.count()
+
+    @cached_property
+    def matches_pending_count(self):
+        return self.matches.filter(ran=False).count()
+
+    @cached_property
+    def matches_played_count(self):
+        return self.matches.filter(ran=True).count()
+
+    @cached_property
+    def tournaments_count(self):
+        return self.tournaments.count()
+
 
 class GameQuerySet(QuerySet):
     def active(self):

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,6 +36,9 @@
             <a class="nav-link" href="{% url 'tournaments' %}">Tournaments</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="{% url 'seasons' %}">Seasons</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="{% url 'games' %}">Games</a>
           </li>
           <li class="nav-item">

--- a/app/templates/matches/detail.html
+++ b/app/templates/matches/detail.html
@@ -20,7 +20,11 @@
 
           <tr>
             <td> Season </td>
-            <td> {{ object.season.name }} </td>
+            <td>
+              <a href={% url 'season_detail' object.season.id %}>
+                {{ object.season.name }}
+              </a>
+            </td>
           </tr>
 
           <tr>

--- a/app/templates/matches/index.html
+++ b/app/templates/matches/index.html
@@ -43,7 +43,12 @@
           {% endif %}
         </td>
 
-        <td> {{ match.season.name }} </td>
+        <td>
+          <a href={% url 'season_detail' match.season.id %}>
+            {{ match.season.name }}
+          </a>
+        </td>
+
         <td> {{ match.game.name }} </td>
         <td> {{ match.ran_at | date:"Y-m-d H:i:s" }} </td>
 

--- a/app/templates/matches/index.html
+++ b/app/templates/matches/index.html
@@ -49,7 +49,12 @@
           </a>
         </td>
 
-        <td> {{ match.game.name }} </td>
+        <td>
+          <a href={% url 'game_detail' match.game.id %}>
+            {{ match.game.name }}
+          </a>
+        </td>
+
         <td> {{ match.ran_at | date:"Y-m-d H:i:s" }} </td>
 
         {% if match.ran and match.replay %}

--- a/app/templates/seasons/detail.html
+++ b/app/templates/seasons/detail.html
@@ -1,0 +1,82 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <h1>{{ object.name }}</h1>
+      <table class="table table-hover table-striped table-sm">
+        <tbody>
+          <tr>
+            <td> Tournaments </td>
+            <td> {{ object.tournaments_count }} </td>
+          </tr>
+          <tr>
+            <td> Matches played </td>
+            <td> {{ object.matches_played_count }} </td>
+          </tr>
+          <tr>
+            <td> Matches pending </td>
+            <td> {{ object.matches_pending_count }} </td>
+          </tr>
+          <tr>
+            <td> Start Date </td>
+            <td> {{ object.start_date }} </td>
+          </tr>
+          <tr>
+            <td> End Date </td>
+            <td> {{ object.end_date }} </td>
+          </tr>
+          <tr>
+            <td> Duration </td>
+            <td> {{ object.duration }} </td>
+          </tr>
+          <tr>
+            <td> Active </td>
+            <td> {{ object.active }} </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <h2> Tournaments </h2>
+
+      <div>
+        <table class="table table-hover table-striped table-sm">
+          <thead>
+            <th scope="col"> Name </th>
+            <th scope="col"> Game </th>
+            <th scope="col"> Mode </th>
+            <th scope="col"> Matches played </th>
+            <th scope="col"> Matches left </th>
+          </thead>
+          <tbody>
+            {% for tournament in object.tournaments.all %}
+            <tr>
+              <td>
+                <a href={% url 'tournament_detail' tournament.id %}>
+                  {{ tournament.name }}
+                </a>
+              </td>
+              <td>
+                <a href={% url 'game_detail' tournament.game.id %}>
+                  {{ tournament.game.name }}
+                </a>
+              </td>
+              <td> {{ tournament.mode }} </td>
+              <td> {{ tournament.played_matches_count }} </td>
+              <td> {{ tournament.pending_matches_count }} </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <div>
+        </div>
+      </div>
+    </div>
+
+    {% endblock %}

--- a/app/templates/seasons/detail.html
+++ b/app/templates/seasons/detail.html
@@ -55,7 +55,7 @@
             <th scope="col"> Matches left </th>
           </thead>
           <tbody>
-            {% for tournament in object.tournaments.all %}
+            {% for tournament in tournaments %}
             <tr>
               <td>
                 <a href={% url 'tournament_detail' tournament.id %}>

--- a/app/templates/seasons/index.html
+++ b/app/templates/seasons/index.html
@@ -18,7 +18,11 @@
     <tbody>
       {% for season in seasons %}
       <tr>
-        <td>{{ season.name }}</td>
+        <td>
+          <a href={% url 'season_detail' season.id %}>
+            {{ season.name }}
+          </a>
+        </td>
         <td>{{ season.active }}</td>
         <td>{{ season.start_date }}</td>
         <td>{{ season.end_date }}</td>

--- a/app/templates/tournaments/index.html
+++ b/app/templates/tournaments/index.html
@@ -24,8 +24,19 @@
             {{ tournament.name }}
           </a>
         </td>
-        <td> {{ tournament.season.name }} </td>
-        <td> {{ tournament.game.name }} </td>
+
+        <td>
+          <a href={% url 'season_detail' tournament.season.id %}>
+            {{ tournament.season.name }}
+          </a>
+        </td>
+
+        <td>
+          <a href={% url 'game_detail' tournament.game.id %}>
+            {{ tournament.game.name }}
+          </a>
+        </td>
+
         <td> {{ tournament.mode }} </td>
         <td> {{ tournament.played_matches_count }} </td>
         <td> {{ tournament.pending_matches_count }} </td>

--- a/app/urls.py
+++ b/app/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("games/<str:pk>/", views.GameDetailView.as_view(), name="game_detail"),
     # Seasons pages
     path("seasons/", views.SeasonListView.as_view(), name="seasons"),
+    path("seasons/<str:pk>/", views.SeasonDetailView.as_view(), name="season_detail"),
     # Match pages
     path("matches/", views.MatchListView.as_view(), name="matches"),
     path("matches/<str:pk>/", views.MatchDetailView.as_view(), name="match_detail"),

--- a/app/views.py
+++ b/app/views.py
@@ -120,6 +120,11 @@ class SeasonListView(generic.ListView):
         return models.Season.objects.all()
 
 
+class SeasonDetailView(generic.DetailView):
+    model = models.Season
+    template_name = "seasons/detail.html"
+
+
 class MatchListView(generic.ListView):
     template_name = "matches/index.html"
     context_object_name = "matches"

--- a/app/views.py
+++ b/app/views.py
@@ -124,6 +124,12 @@ class SeasonDetailView(generic.DetailView):
     model = models.Season
     template_name = "seasons/detail.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        season = self.get_object()
+        context["tournaments"] = season.tournaments.order_by("-end_date")[:25]
+        return context
+
 
 class MatchListView(generic.ListView):
     template_name = "matches/index.html"


### PR DESCRIPTION
This PR enables the season views to be reachable from multiple pages (matches, tournaments, navbar, etc).

it also adds a few missing links to the game detail view