### PR TITLE
Improve agent games played count performance

### DIFF
--- a/app/celery.py
+++ b/app/celery.py
@@ -18,10 +18,6 @@ app.conf.update(
 )
 
 app.conf.beat_schedule = {
-    "refresh_agent_count_cache": {
-        "task": "app.tasks.refresh_agent_count_cache",
-        "schedule": 5.0,
-    },
     "automated_manager": {
         "task": "app.tasks.automated_manager",
         "schedule": 10.0,

--- a/app/models.py
+++ b/app/models.py
@@ -9,7 +9,6 @@ import humanize
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.cache import cache
 from django.db import models
 from django.db.models import F, QuerySet
 from django.utils import timezone
@@ -85,16 +84,9 @@ class Agent(BaseModel):
     def pretty_win_ratio(self):
         return f"{self.win_ratio * 100.0:.2f}"
 
-    @cached_property
+    @property
     def games_played_count(self):
-        cache_key = f"games_played_count__{self.id}__{self.current_ratings.id}"
-        count = cache.get(cache_key)
-
-        if count is None:
-            count = self.games_played.count()
-            cache.set(cache_key, count, timeout=30)
-
-        return count
+        return int(self.wins + self.loses + self.draws * 2)
 
     @property
     def games_played(self):

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -13,16 +13,6 @@ def push_metric(data):
 
 
 @celery.task
-def refresh_agent_count_cache():
-    """
-    This task refreshes the cache for "games_played_count" to stay warm.  This
-    significantly improves response times for the agent api and index view.
-    """
-    for agent in models.Agent.objects.all():
-        agent.games_played_count
-
-
-@celery.task
 def automated_manager():
     """
     Creates things automatically

--- a/app/tests/test_tasks.py
+++ b/app/tests/test_tasks.py
@@ -6,39 +6,6 @@ from django.utils import timezone
 from app import factories, models, tasks
 
 
-class RefreshAgentCountCacheTestCase(TestCase):
-    def setUp(self):
-        self.game = factories.GameFactory()
-        self.season = factories.SeasonFactory()
-        self.tournament = factories.TournamentFactory(
-            game=self.game, season=self.season
-        )
-        self.agent1 = factories.AgentFactory(game=self.game)
-        self.agent2 = factories.AgentFactory(game=self.game)
-        self.match1 = factories.MatchFactory(
-            player1=self.agent1,
-            player2=self.agent2,
-            season=self.season,
-            tournament=self.tournament,
-            game=self.game,
-            result=1,
-        )
-        self.match2 = factories.MatchFactory(
-            player1=self.agent1,
-            player2=self.agent2,
-            season=self.season,
-            tournament=self.tournament,
-            game=self.game,
-            result=0,
-        )
-
-    def test_for_smoke(self):
-        """
-        Basic smoke test, so we don't have any bad surprises
-        """
-        tasks.refresh_agent_count_cache()
-
-
 class AutomatedManagerTestcase(TestCase):
     def setUp(self):
         self.game = factories.GameFactory()


### PR DESCRIPTION
We use `wins + loses + draws * 2.0` to calculate the number of played matches, rather than doing a sql query to count it. 