### PR TITLE
Setup a celery heartbeat

### DIFF
--- a/app/celery.py
+++ b/app/celery.py
@@ -18,6 +18,10 @@ app.conf.update(
 )
 
 app.conf.beat_schedule = {
+    "heartbeat": {
+        "task": "app.tasks.heartbeat",
+        "schedule": 1.0,
+    },
     "automated_manager": {
         "task": "app.tasks.automated_manager",
         "schedule": 10.0,

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -120,7 +120,8 @@
           Open Tournaments: {{ open_tournament_count }} <br>
           Current Season: {{ current_season_name }} <br>
           Pending Matches: {{ pending_matches }} <br>
-          Oldest Pending Match Age: {{ oldest_pending_match_age }}
+          Oldest Pending Match Age: {{ oldest_pending_match_age }} <br>
+          Last Celery Heartbeat: {{ celery_heartbeat }}
         </p>
       </div>
     </div>

--- a/colosseum_website/settings/base.py
+++ b/colosseum_website/settings/base.py
@@ -241,3 +241,6 @@ CORS_ALLOW_ALL_ORIGINS = True
 
 # Replay
 REPLAY_JS_BUNDLE_URL = config("REPLAY_JS_BUNDLE_URL", default="")
+
+
+CELERY_HEARTBEAT_KEY = "celery_heartbeat"


### PR DESCRIPTION
This patch adds a periodic task that stores when the task run. This can
be used as a celery heart beat to know when was the last time that
celery was running. This information is then shown in the home page
under the ``Stats'' section.