### PR TITLE
Fix trophy generation failing for timed tournaments

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -57,6 +57,13 @@ def update_tournament_state(tournament):
             f"{tournament.mode} Tournament {tournament.id} was set to done=true"
         )
 
+    if tournament.done and not tournament.has_pending_matches:
+        """
+        This is important for timed tournaments, since they may be "done", in
+        the sense that the time window for it has passed, but there may be
+        pending matches to be played.  These matches were created before the
+        tournament was marked as done.
+        """
         create_trophies(tournament)
 
 


### PR DESCRIPTION
this was happening because matches were created while the tournament was active, but when it gets marked as `done` the trophies try to get generated. However, there are still pending matches, that were created before it closed.

the fix is to check if the tournament is done, and that it has no pending matches. 